### PR TITLE
CHORE: 장고 corsheader 설정

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -43,6 +43,7 @@ INSTALLED_APPS = [
     "accounts",
     "rest_framework",
     "django_extensions",
+    "corsheaders",
 ]
 
 MIDDLEWARE = [
@@ -54,6 +55,8 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "debug_toolbar.middleware.DebugToolbarMiddleware",
+    "corsheaders.middleware.CorsMiddleware",
+    "django.middleware.common.CommonMiddleware",
 ]
 
 ROOT_URLCONF = "backend.urls"
@@ -144,3 +147,4 @@ REST_FRAMEWORK = {
         "rest_framework.permissions.IsAuthenticated",
     ]
 }
+CORS_ORIGIN_WHITELIST = ["http://localhost:3000"]

--- a/backend/instagram/views.py
+++ b/backend/instagram/views.py
@@ -10,4 +10,4 @@ from rest_framework.permissions import AllowAny
 class PostViewSet(ModelViewSet):
     queryset = Post.objects.all()
     serializer_class = PostSerializer
-    permission_classes = [AllowAny]
+    permission_classes = [AllowAny]  # FIXME: 인증 적용


### PR DESCRIPTION
BE
- 리액트에서 장고 api의 도메인을 받을 수 있도록 장고 settings에 설정 추가